### PR TITLE
chore: Clean up readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,6 @@ Formerly known as `ibctest`, `interchaintest` was built and initially maintained
 This fork is maintained by the Interchain Operations team at [Hypha Worker Co-operative](https://hypha.coop/).
 
 [![License: Apache-2.0](https://img.shields.io/github/license/strangelove-ventures/interchaintest.svg?style=flat-square)](https://github.com/cosmos/interchaintest/blob/main/LICENSE)
-[![Go Report Card](https://goreportcard.com/badge/github.com/cosmos/interchaintest)](https://goreportcard.com/report/github.com/cosmos/interchaintest)
 </div>
 
 🌌 Why use `interchaintest`?
@@ -22,22 +21,20 @@ We built `interchaintest` to extract patterns and create a generic test harness:
 
 Read more at the [Announcing `interchaintest` blog post](https://strange.love/blog/announcing-interchaintest).
 
-🌌🌌 Who benefits from `interchaintest`?
+🌌 Who benefits from `interchaintest`?
 =============================
 
 `interchaintest` is for developers who expect top-shelf testing tools when working on blockchain protocols such as Cosmos or Ethereum.
 
 
-🌌🌌🌌 What does `interchaintest` do?
+🌌 What does `interchaintest` do?
 =============================
 
 `interchaintest` is a framework for testing blockchain functionality and interoperability between chains, primarily with the Inter-Blockchain Communication (IBC) protocol.
 
 Want to quickly spin up custom testnets and dev environments to test IBC, [Relayer](https://github.com/cosmos/relayer) setup, chain infrastructure, smart contracts, etc.? `interchaintest` orchestrates Go tests that utilize Docker containers for multiple [IBC](https://www.ibcprotocol.dev/)-compatible blockchains.
 
-
-
-🌌🌌🌌🌌 How do I use it?
+🌌 How do I use it?
 =============================
 
 ## As a Module
@@ -56,43 +53,15 @@ There's also an option to [build and run `interchaintest` as a binary](./docs/bu
 - [Environment Variable Options](./docs/envOptions.md)
 - [Retaining Data on Failed Tests](./docs/retainingDataOnFailedTests.md)
 
-
-🌌🌌🌌🌌🌌 Extras
+🌌 Extras
 =============================
+## Maintained Branches
 
+|                 **Branch Name**                  | **IBC-Go** | **Cosmos-SDK** |
+| :----------------------------------------------: | :--------: | :------------: |
+| [main](https://github.com/cosmos/interchaintest) |    v10     |     v0.53      |
 
-
-### Maintained Branches
-
-|                                **Branch Name**                               | **IBC-Go** | **Cosmos-sdk** |
-|:----------------------------------------------------------------------------:|:----------:|:--------------:|
-|     [main](https://github.com/cosmos/interchaintest)           |     v8     |      v0.50     |
-|     [v7](https://github.com/cosmos/interchaintest/tree/v7)     |     v7     |      v0.47     |
-
-### Deprecated Branches
-
-These are branches that we no longer actively update or maintain but may be of use if a chain is running older versions of the `Cosmos SDK ` or `IBC Go`. Please see the [Backport Policy](#backport-policy) below.
-
-
-|                               **Branch Name**                                | **IBC-Go** | **Cosmos-sdk** | **Deprecated Date** |
-|:----------------------------------------------------------------------------:|:----------:|:--------------:|:--------------------:|
-|     [v6](https://github.com/cosmos/interchaintest/tree/v6)     |     v6     |     v0.46      |     Sept 5 2023      |
-|     [v5](https://github.com/cosmos/interchaintest/tree/v5)     |     v5     |     v0.46      |     Aug 11 2023      |
-|     [v4](https://github.com/cosmos/interchaintest/tree/v4)     |     v4     |     v0.45      |     Aug 11 2023      |
-| [v4-ics](https://github.com/cosmos/interchaintest/tree/v4-ics) |     v4     |  v0.45.x-ics   |     Aug 11 2023      |
-|     [v3](https://github.com/cosmos/interchaintest/tree/v3)     |     v3     |     v0.45      |     June 25 2023     |
-| [v3-ics](https://github.com/cosmos/interchaintest/tree/v3-ics) |     v3     |  v0.45.11-ics  |    April 24 2023     |
-
-
-#### Backport Policy:
-Strangelove maintains `n` and `n - 1` branches of `interchaintest`, `n` being current `main`.
-
-We strive to keep `interchaintest` inline with the latest from the ibc-go and cosmos sdk teams. Once an alpha versions of the next major ibc-go version is released, we will discontinue `n - 1` and branch off a new `n`.
-
-**Recommendation:** Even if your chain uses an older version of ibc-go, try importing from `main`. This should work unless you are decoding transactions that require a specific ibc-go version.
-
-If there is a feature you would like backported to an older branch, make an issue! We are happy to work with you.
-
+We strive to keep `interchaintest` aligned to stable versions from the IBC-Go and Cosmos SDK teams.
 
 ## Contributing
 
@@ -104,5 +73,5 @@ Please read the [logging style guide](./docs/logging.md).
 
 Significant bugs that were more easily fixed with `interchaintest`:
 
-- [Juno network halt reproduction](https://github.com/cosmos/interchaintest/pull/7)
-- [Juno network halt fix confirmation](https://github.com/cosmos/interchaintest/pull/8)
+- [Juno network halt reproduction](https://github.com/strangelove-ventures/interchaintest/pull/7)
+- [Juno network halt fix confirmation](https://github.com/strangelove-ventures/interchaintest/pull/8)


### PR DESCRIPTION
* Remove report card
* Set `main` as the one maintained branch
* Remove deprecated branches