### PR TITLE
fix: Use gaia repo as the image source

### DIFF
--- a/configuredChains.yaml
+++ b/configuredChains.yaml
@@ -343,7 +343,7 @@ gaia:
   gas: auto
   trusting-period: 504h
   images:
-    - repository: ghcr.io/strangelove-ventures/heighliner/gaia
+    - repository: ghcr.io/cosmos/gaia
       uid-gid: 1025:1025
   no-host-mount: false
 

--- a/conformance/test.go
+++ b/conformance/test.go
@@ -93,12 +93,6 @@ var relayerTestCaseConfigs = [...]RelayerTestCaseConfig{
 		PreRelayerStart: preRelayerStartNoTimeout,
 		Test:            testPacketRelaySuccess,
 	},
-	// { // Relative timeouts using block height are not supported as of IBC v9.0.0
-	// 	Name:                        "height timeout",
-	// 	RequiredRelayerCapabilities: []relayer.Capability{relayer.HeightTimeout},
-	// 	PreRelayerStart:             preRelayerStartHeightTimeout,
-	// 	Test:                        testPacketRelayFail,
-	// },
 	{
 		Name:                        "timestamp timeout",
 		RequiredRelayerCapabilities: []relayer.Capability{relayer.TimestampTimeout},
@@ -279,8 +273,7 @@ func Test(t *testing.T, ctx context.Context, cfs []interchaintest.ChainFactory, 
 // Given 2 chains, Chain A and Chain B, this test asserts:
 // 1. Successful IBC transfer from A -> B and B -> A.
 // 2. Proper handling of no timeout from A -> B and B -> A.
-// 3. Proper handling of height timeout from A -> B and B -> A.
-// 4. Proper handling of timestamp timeout from A -> B and B -> A.
+// 3. Proper handling of timestamp timeout from A -> B and B -> A.
 // If a non-nil relayerImpl is passed, it is assumed that the chains are already started.
 func TestChainPair(
 	t *testing.T,
@@ -372,15 +365,6 @@ func preRelayerStartNoTimeout(ctx context.Context, t *testing.T, testCase *Relay
 	// TODO should we wait here to make sure it successfully relays a packet beyond the default timeout period?
 	// would need to shorten the chain default timeouts somehow to make that a feasible test
 }
-
-// Relative timeouts using block height are not supported as of IBC v9.0.0
-// func preRelayerStartHeightTimeout(ctx context.Context, t *testing.T, testCase *RelayerTestCase, srcChain ibc.Chain, dstChain ibc.Chain, channels []ibc.ChannelOutput) {
-// 	t.Helper()
-// 	ibcTimeoutHeight := ibc.IBCTimeout{Height: 10}
-// 	sendIBCTransfersFromBothChainsWithTimeout(ctx, t, testCase, srcChain, dstChain, channels, &ibcTimeoutHeight)
-// 	// wait for both chains to produce 15 blocks to expire timeout
-// 	require.NoError(t, testutil.WaitForBlocks(ctx, 15, srcChain, dstChain), "failed to wait for blocks")
-// }
 
 func preRelayerStartTimestampTimeout(ctx context.Context, t *testing.T, testCase *RelayerTestCase, srcChain ibc.Chain, dstChain ibc.Chain, channels []ibc.ChannelOutput) {
 	t.Helper()

--- a/conformance/test.go
+++ b/conformance/test.go
@@ -373,13 +373,14 @@ func preRelayerStartNoTimeout(ctx context.Context, t *testing.T, testCase *Relay
 	// would need to shorten the chain default timeouts somehow to make that a feasible test
 }
 
-func preRelayerStartHeightTimeout(ctx context.Context, t *testing.T, testCase *RelayerTestCase, srcChain ibc.Chain, dstChain ibc.Chain, channels []ibc.ChannelOutput) {
-	t.Helper()
-	ibcTimeoutHeight := ibc.IBCTimeout{Height: 10}
-	sendIBCTransfersFromBothChainsWithTimeout(ctx, t, testCase, srcChain, dstChain, channels, &ibcTimeoutHeight)
-	// wait for both chains to produce 15 blocks to expire timeout
-	require.NoError(t, testutil.WaitForBlocks(ctx, 15, srcChain, dstChain), "failed to wait for blocks")
-}
+// Relative timeouts using block height are not supported as of IBC v9.0.0
+// func preRelayerStartHeightTimeout(ctx context.Context, t *testing.T, testCase *RelayerTestCase, srcChain ibc.Chain, dstChain ibc.Chain, channels []ibc.ChannelOutput) {
+// 	t.Helper()
+// 	ibcTimeoutHeight := ibc.IBCTimeout{Height: 10}
+// 	sendIBCTransfersFromBothChainsWithTimeout(ctx, t, testCase, srcChain, dstChain, channels, &ibcTimeoutHeight)
+// 	// wait for both chains to produce 15 blocks to expire timeout
+// 	require.NoError(t, testutil.WaitForBlocks(ctx, 15, srcChain, dstChain), "failed to wait for blocks")
+// }
 
 func preRelayerStartTimestampTimeout(ctx context.Context, t *testing.T, testCase *RelayerTestCase, srcChain ibc.Chain, dstChain ibc.Chain, channels []ibc.ChannelOutput) {
 	t.Helper()

--- a/conformance/test.go
+++ b/conformance/test.go
@@ -93,12 +93,12 @@ var relayerTestCaseConfigs = [...]RelayerTestCaseConfig{
 		PreRelayerStart: preRelayerStartNoTimeout,
 		Test:            testPacketRelaySuccess,
 	},
-	{
-		Name:                        "height timeout",
-		RequiredRelayerCapabilities: []relayer.Capability{relayer.HeightTimeout},
-		PreRelayerStart:             preRelayerStartHeightTimeout,
-		Test:                        testPacketRelayFail,
-	},
+	// { // Relative timeouts using block height are not supported as of IBC v9.0.0
+	// 	Name:                        "height timeout",
+	// 	RequiredRelayerCapabilities: []relayer.Capability{relayer.HeightTimeout},
+	// 	PreRelayerStart:             preRelayerStartHeightTimeout,
+	// 	Test:                        testPacketRelayFail,
+	// },
 	{
 		Name:                        "timestamp timeout",
 		RequiredRelayerCapabilities: []relayer.Capability{relayer.TimestampTimeout},

--- a/examples/cosmos/chain_genesis_stake_test.go
+++ b/examples/cosmos/chain_genesis_stake_test.go
@@ -31,15 +31,25 @@ func TestChainGenesisUnequalStake(t *testing.T) {
 		balance    = 1_000_000_000_000
 	)
 	validators := 2
+
+	DefaultGenesis := []cosmos.GenesisKV{
+		// configure the feemarket module
+		cosmos.NewGenesisKV("app_state.feemarket.params.enabled", false),
+		cosmos.NewGenesisKV("app_state.feemarket.params.min_base_gas_price", "0.001"),
+		cosmos.NewGenesisKV("app_state.feemarket.params.max_block_utilization", "50000000"),
+		cosmos.NewGenesisKV("app_state.feemarket.state.base_gas_price", "0.001"),
+	}
+
 	cf := interchaintest.NewBuiltinChainFactory(zaptest.NewLogger(t), []*interchaintest.ChainSpec{
 		{
 			Name:          "gaia",
 			ChainName:     "gaia",
-			Version:       "v15.1.0",
+			Version:       "v25.1.0",
 			NumValidators: &validators,
 			NumFullNodes:  &numFullNodesZero,
 			ChainConfig: ibc.ChainConfig{
-				Denom: denom,
+				Denom:         denom,
+				ModifyGenesis: cosmos.ModifyGenesis(DefaultGenesis),
 				ModifyGenesisAmounts: func(i int) (sdk.Coin, sdk.Coin) {
 					if i == 0 {
 						return sdk.NewCoin(denom, sdkmath.NewInt(balance)), sdk.NewCoin(denom, sdkmath.NewInt(val1_stake))

--- a/examples/cosmos/chain_upgrade_ibc_test.go
+++ b/examples/cosmos/chain_upgrade_ibc_test.go
@@ -117,7 +117,7 @@ func CosmosChainUpgradeIBCTest(t *testing.T, chainName, initialVersion, upgradeC
 
 	// Get a relayer instance
 	rf := interchaintest.NewBuiltinRelayerFactory(
-		ibc.CosmosRly,
+		ibc.Hermes,
 		zaptest.NewLogger(t),
 		relayer.StartupFlags("-b", "100"),
 	)

--- a/examples/cosmos/chain_upgrade_ibc_test.go
+++ b/examples/cosmos/chain_upgrade_ibc_test.go
@@ -34,7 +34,7 @@ func TestJunoUpgradeIBC(t *testing.T) {
 }
 
 func TestGaiaUpgradeIBC(t *testing.T) {
-	CosmosChainUpgradeIBCTest(t, "gaia", "v17.3.0", "ghcr.io/strangelove-ventures/heighliner/gaia", "v18.1.0", "v18")
+	CosmosChainUpgradeIBCTest(t, "gaia", "v24.0.0", "ghcr.io/cosmos/gaia", "v25.1.0", "v25.1.0")
 }
 
 func CosmosChainUpgradeIBCTest(t *testing.T, chainName, initialVersion, upgradeContainerRepo, upgradeVersion string, upgradeName string) {
@@ -59,6 +59,11 @@ func CosmosChainUpgradeIBCTest(t *testing.T, chainName, initialVersion, upgradeC
 			cosmos.NewGenesisKV("app_state.gov.params.voting_period", votingPeriod),
 			cosmos.NewGenesisKV("app_state.gov.params.max_deposit_period", maxDepositPeriod),
 			cosmos.NewGenesisKV("app_state.gov.params.min_deposit.0.denom", "uatom"),
+			// configure the feemarket module
+			cosmos.NewGenesisKV("app_state.feemarket.params.enabled", false),
+			cosmos.NewGenesisKV("app_state.feemarket.params.min_base_gas_price", "0.001"),
+			cosmos.NewGenesisKV("app_state.feemarket.params.max_block_utilization", "50000000"),
+			cosmos.NewGenesisKV("app_state.feemarket.state.base_gas_price", "0.001"),
 		}
 	}
 
@@ -68,15 +73,20 @@ func CosmosChainUpgradeIBCTest(t *testing.T, chainName, initialVersion, upgradeC
 			ChainName: chainName,
 			Version:   initialVersion,
 			ChainConfig: ibc.ChainConfig{
+				GasPrices:     "0.001uatom",
 				ModifyGenesis: cosmos.ModifyGenesis(shortVoteGenesis),
 			},
 			NumValidators: &numValsOne,
 			NumFullNodes:  &numFullNodesZero,
 		},
 		{
-			Name:          "gaia",
-			ChainName:     "gaia-ibc",
-			Version:       "v7.0.3",
+			Name:      "gaia",
+			ChainName: "gaia-ibc",
+			Version:   "v25.1.0",
+			ChainConfig: ibc.ChainConfig{
+				GasPrices:     "0.001uatom",
+				ModifyGenesis: cosmos.ModifyGenesis(shortVoteGenesis),
+			},
 			NumValidators: &numValsOne,
 			NumFullNodes:  &numFullNodesZero,
 		},

--- a/examples/cosmos/sdk_boundary_test.go
+++ b/examples/cosmos/sdk_boundary_test.go
@@ -33,7 +33,7 @@ func TestSDKBoundaries(t *testing.T) {
 			name: "sdk 45 <-> 50",
 			chainSpecs: []*interchaintest.ChainSpec{
 				{
-					Name: "gaia", ChainName: "gaia", Version: "v7.0.3", // sdk 0.45.6
+					Name: "ibc-go-simd", ChainName: "simd-45", Version: "v4.4.0", // sdk v0.45.15
 					NumValidators: &numValsOne, NumFullNodes: &numFullNodesZero,
 				},
 				{

--- a/local-interchain/docs/WINDOWS.md
+++ b/local-interchain/docs/WINDOWS.md
@@ -60,7 +60,7 @@ After installation, open a new cmd or shell, and you will be able to run `go ver
 ### 4. Downloading Make
 Make is a tool which controls the generation of executables and other non-source files of a program from the source files. It is necessary for building *`makefiles`*.
 
-Make does not come with Windows, so we need to download the make binary which you can find provided by GNU [here](https://www.gnu.org/software/make/) and download the Binaries zip, or go to [this link](https://sourceforge.net/projects/gnuwin32/files/make/3.81/make-3.81-bin.zip/download?use_mirror=kent&download=) directly and begin downloading.
+Make does not come with Windows, so we need to download the make binary which you can find provided by GNU (https://www.gnu.org/software/make) and download the Binaries zip, or go to [this link](https://sourceforge.net/projects/gnuwin32/files/make/3.81/make-3.81-bin.zip/download?use_mirror=kent&download=) directly and begin downloading.
 
 1. Extract the downloaded zip file
 2. Go to the *`bin`*  folder, copy *`make.exe`*

--- a/local-interchain/docs/WINDOWS.md
+++ b/local-interchain/docs/WINDOWS.md
@@ -60,7 +60,9 @@ After installation, open a new cmd or shell, and you will be able to run `go ver
 ### 4. Downloading Make
 Make is a tool which controls the generation of executables and other non-source files of a program from the source files. It is necessary for building *`makefiles`*.
 
-Make does not come with Windows, so we need to download the make binary which you can find provided by GNU (https://www.gnu.org/software/make) and download the Binaries zip, or go to [this link](https://sourceforge.net/projects/gnuwin32/files/make/3.81/make-3.81-bin.zip/download?use_mirror=kent&download=) directly and begin downloading.
+<!-- markdown-link-check-disable -->
+Make does not come with Windows, so we need to download the make binary which you can find provided by GNU [here](https://www.gnu.org/software/make/) and download the Binaries zip, or go to [this link](https://sourceforge.net/projects/gnuwin32/files/make/3.81/make-3.81-bin.zip/download?use_mirror=kent&download=) directly and begin downloading.
+<!-- markdown-link-check-enable -->
 
 1. Extract the downloaded zip file
 2. Go to the *`bin`*  folder, copy *`make.exe`*


### PR DESCRIPTION
Use image from cosmos/gaia for the interchaintest container.
This required the following changes:
- Bumping Gaia from v7 or v15 to a package version available in the cosmos/gaia repo
- Dropping the height timeout test (unsupported since IBC v9.0.0)
- Switching the upgrade test from rly to hermes