### PR TITLE
fix: Use the reserved listener address for Docker port bindings

### DIFF
--- a/dockerutil/ports.go
+++ b/dockerutil/ports.go
@@ -48,9 +48,10 @@ func GetPort(port int) (nat.PortBinding, *net.TCPListener, error) {
 		return nat.PortBinding{}, nil, err
 	}
 
+	tcpAddr := l.Addr().(*net.TCPAddr)
 	return nat.PortBinding{
-		HostIP:   "0.0.0.0",
-		HostPort: fmt.Sprint(l.Addr().(*net.TCPAddr).Port),
+		HostIP:   tcpAddr.IP.String(),
+		HostPort: fmt.Sprint(tcpAddr.Port),
 	}, l, nil
 }
 


### PR DESCRIPTION
## Summary

  This changes `GetPort` to derive Docker `PortBinding.HostIP` and `HostPort` from the actual TCP listener address.

  Previously, interchaintest reserved ports by opening a listener on `127.0.0.1:<port>`, but returned a Docker port binding with `HostIP: "0.0.0.0"`. This meant the reserved host address and the Docker publish address
could differ.

  With this change, the returned `PortBinding` is built from the listener itself:

  ## Motivation

  OpenListener is the source of truth for reserving an available host port. The Docker PortBinding should use the same bound address rather than independently choosing a different host IP.

  This matters on newer Docker versions where bridge networking and port publishing behavior has been tightened. Docker Engine 28 changed port publishing and bridge-network firewall behavior, and Docker documents that
  binding to 127.0.0.1 restricts the published port to the Docker host.


  ## Behavior Change

  Instead of always publishing reserved ports on 0.0.0.0, interchaintest now publishes the port on the same IP address that was actually reserved by the temporary listener.

  For the current OpenListener implementation, this means Docker receives 127.0.0.1:<port>, matching the listener reservation.